### PR TITLE
Update Readme with Eclipse integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.so
 *.bundle
 /.vscode/
+.project
 Gemfile.lock
 
 # rspec failure tracking

--- a/README.md
+++ b/README.md
@@ -26,4 +26,12 @@ Run `readapt serve` to start the server. The default client connection is host 1
 
 ## Integrations
 
-Readapt is available for Visual Studio Code in the [Ruby Debug extension](https://marketplace.visualstudio.com/items?itemName=castwide.ruby-debug).
+Plug-ins and extensions using Readapt are available for the following editors:
+
+* **Visual Studio Code**
+    * Marketplace: https://marketplace.visualstudio.com/items?itemName=castwide.ruby-debug
+    * GitHub: https://github.com/castwide/vscode-ruby-debug
+
+* **Eclipse**
+    * Marketplace: https://marketplace.eclipse.org/content/ruby-solargraph
+    * GitHub: https://github.com/PyvesB/eclipse-solargraph


### PR DESCRIPTION
Eclipse now has some basic integration with Readapt!

Simple example:
![debugger](https://user-images.githubusercontent.com/10694593/74588655-4f58f300-4ff6-11ea-8fee-764f0859d785.png)
