### PR TITLE
Fix for #8

### DIFF
--- a/lib/readapt/output.rb
+++ b/lib/readapt/output.rb
@@ -6,7 +6,7 @@ module Readapt
 
     def receiving data
       send_event('output', {
-        output: data,
+        output: data.force_encoding('utf-8'),
         category: 'stdout'
       })
     end


### PR DESCRIPTION
It seems that forcing the output to UTF/8 fixes the problem we see in Bug #8 as to_json expects UT-8 encoding.